### PR TITLE
Add ElevenLabs speech synthesis feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ EEG-powered hypnosis assistant for self-exploration and QHHT. Tracks trance dept
 
 ## Getting Started
 
-A simple CLI is included to demonstrate the basic functionality. No external
-packages are required beyond Python 3.8+.
+A simple CLI is included to demonstrate the basic functionality.
+Install dependencies with `pip install -r requirements.txt`.
 
 ```bash
 # Stream simulated EEG data
@@ -39,5 +39,8 @@ python -m thetagate monitor --interval 1
 
 # Run a sample hypnosis script
 python -m thetagate run-script scripts/sample.txt --delay 3
+
+# Run the script with speech synthesis (requires ELEVENLABS_API_KEY)
+python -m thetagate run-script scripts/sample.txt --voice-id "YOUR_VOICE_ID"
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-# No external dependencies required for the base application.
+elevenlabs>=2.3.0

--- a/src/thetagate/__init__.py
+++ b/src/thetagate/__init__.py
@@ -1,5 +1,5 @@
 """ThetaGate package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]

--- a/src/thetagate/cli.py
+++ b/src/thetagate/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 from pathlib import Path
-from . import eeg, trance, script_runner
+from . import eeg, trance, script_runner, speech
 
 
 def run(args: argparse.Namespace) -> None:
@@ -18,7 +18,17 @@ def run(args: argparse.Namespace) -> None:
         path = Path(args.file)
         lines = path.read_text().splitlines()
         print(f"Running script: {path}")
-        script_runner.run_script(lines, delay=args.delay)
+        settings = None
+        if args.voice_id:
+            settings = speech.SpeechSettings(
+                voice_id=args.voice_id,
+                stability=args.stability,
+                similarity_boost=args.similarity_boost,
+                style=args.style,
+                use_speaker_boost=args.speaker_boost,
+                api_key=args.api_key,
+            )
+        script_runner.run_script(lines, delay=args.delay, speech_settings=settings)
     else:
         print("Unknown command")
 
@@ -33,6 +43,26 @@ def parse_args(argv=None) -> argparse.Namespace:
     sc = sub.add_parser("run-script", help="Run hypnosis script")
     sc.add_argument("file", help="Path to script file")
     sc.add_argument("--delay", type=float, default=5.0, help="Delay between lines")
+    sc.add_argument("--voice-id", help="ElevenLabs voice ID to use for speech")
+    sc.add_argument("--stability", type=float, default=0.75, help="Voice stability")
+    sc.add_argument(
+        "--similarity-boost",
+        type=float,
+        default=0.75,
+        help="Voice similarity boost",
+    )
+    sc.add_argument("--style", type=float, default=None, help="Voice style")
+    sc.add_argument(
+        "--no-speaker-boost",
+        dest="speaker_boost",
+        action="store_false",
+        help="Disable speaker boost",
+    )
+    sc.add_argument(
+        "--api-key",
+        help="ElevenLabs API key (defaults to ELEVENLABS_API_KEY env variable)",
+    )
+
 
     return parser.parse_args(argv)
 

--- a/src/thetagate/script_runner.py
+++ b/src/thetagate/script_runner.py
@@ -1,11 +1,20 @@
-"""Play back a hypnosis script."""
+"""Play back a hypnosis script with optional speech synthesis."""
 
 import time
-from typing import Iterable
+from typing import Iterable, Optional
+
+from . import speech
 
 
-def run_script(lines: Iterable[str], delay: float = 5.0) -> None:
-    """Print each line with a delay."""
+def run_script(
+    lines: Iterable[str],
+    delay: float = 5.0,
+    speech_settings: Optional[speech.SpeechSettings] = None,
+) -> None:
+    """Print each line with a delay and optionally speak it."""
     for line in lines:
-        print(line.strip())
+        text = line.strip()
+        print(text)
+        if speech_settings:
+            speech.speak(text, speech_settings)
         time.sleep(delay)

--- a/src/thetagate/speech.py
+++ b/src/thetagate/speech.py
@@ -1,0 +1,49 @@
+"""Utilities for ElevenLabs speech synthesis."""
+
+from dataclasses import dataclass
+from typing import Optional, Iterable
+import os
+
+from elevenlabs import play
+from elevenlabs.client import ElevenLabs
+from elevenlabs.types import VoiceSettings
+
+
+@dataclass
+class SpeechSettings:
+    """Configuration for speech synthesis."""
+
+    voice_id: str
+    stability: float = 0.75
+    similarity_boost: float = 0.75
+    style: Optional[float] = None
+    use_speaker_boost: bool = True
+    api_key: Optional[str] = None
+
+
+def synthesize(text: str, settings: SpeechSettings) -> bytes:
+    """Generate speech audio from text using ElevenLabs."""
+    client = ElevenLabs(api_key=settings.api_key or os.getenv("ELEVENLABS_API_KEY"))
+    vs = VoiceSettings(
+        stability=settings.stability,
+        similarity_boost=settings.similarity_boost,
+        style=settings.style,
+        use_speaker_boost=settings.use_speaker_boost,
+    )
+    audio = client.text_to_speech.convert(
+        voice_id=settings.voice_id,
+        text=text,
+        voice_settings=vs,
+        output_format="mp3_44100_128",
+    )
+    if isinstance(audio, (bytes, bytearray)):
+        return bytes(audio)
+    return b"".join(audio)
+
+
+def speak(text: str, settings: SpeechSettings, play_audio: bool = True) -> bytes:
+    """Generate and optionally play speech audio."""
+    audio = synthesize(text, settings)
+    if play_audio:
+        play(audio)
+    return audio


### PR DESCRIPTION
## Summary
- integrate ElevenLabs API for speech synthesis
- add `speech.py` module
- extend script runner to optionally speak lines
- add CLI flags for speech settings
- bump package version to 0.2.0
- update docs and requirements

## Testing
- `PYTHONPATH=src python -m thetagate.cli --help`
- `PYTHONPATH=src python -m thetagate.cli run-script --help`
- `PYTHONPATH=src python -m thetagate.cli run-script scripts/sample.txt --delay 0 | head -n 5`
- `PYTHONPATH=src python -m thetagate.cli run-script scripts/sample.txt --delay 0 --voice-id test --api-key invalid-key` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685415ae9a6083249496f207afbba5d0