### PR TITLE
Add alpha-theta monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ EEG-powered hypnosis assistant for self-exploration and QHHT. Tracks trance dept
 - Live brainwave visualization (Delta, Theta, Alpha, Beta)
 - Custom hypnosis script playback with binaural support
 - Real-time trance depth detection with scoring system
+- Alpha-theta ratio and crossover alerts
 - EEG data logging + session replay
 - QHHT practitioner dashboard (in development)
 
@@ -34,7 +35,7 @@ A simple CLI is included to demonstrate the basic functionality.
 Install dependencies with `pip install -r requirements.txt`.
 
 ```bash
-# Stream simulated EEG data
+# Stream simulated EEG data with crossover alerts
 python -m thetagate monitor --interval 1
 
 # Run a sample hypnosis script

--- a/src/thetagate/cli.py
+++ b/src/thetagate/cli.py
@@ -11,7 +11,15 @@ def run(args: argparse.Namespace) -> None:
         try:
             for sample in eeg.stream(interval=args.interval):
                 tscore = trance.score(sample)
-                print(f"Sample {sample} :: Trance score {tscore:.2f}")
+                ratio = trance.alpha_theta_ratio(sample)
+                crossover = trance.alpha_theta_crossover(sample)
+                msg = (
+                    f"Sample {sample} :: Trance score {tscore:.2f} :: "
+                    f"theta/alpha {ratio:.2f}"
+                )
+                if crossover and not args.no_crossover_alert:
+                    msg += " << alpha-theta crossover"
+                print(msg)
         except KeyboardInterrupt:
             print("\nStopping stream.")
     elif args.command == "run-script":
@@ -39,6 +47,11 @@ def parse_args(argv=None) -> argparse.Namespace:
 
     mon = sub.add_parser("monitor", help="Stream simulated EEG")
     mon.add_argument("--interval", type=float, default=1.0, help="Sample interval")
+    mon.add_argument(
+        "--no-crossover-alert",
+        action="store_true",
+        help="Suppress alpha-theta crossover messages",
+    )
 
     sc = sub.add_parser("run-script", help="Run hypnosis script")
     sc.add_argument("file", help="Path to script file")

--- a/src/thetagate/trance.py
+++ b/src/thetagate/trance.py
@@ -1,4 +1,4 @@
-"""Simple trance depth calculation."""
+"""Utility functions for estimating trance depth from EEG samples."""
 
 from typing import Dict
 
@@ -14,3 +14,17 @@ def score(sample: Dict[str, float]) -> float:
     if denominator == 0:
         return 0.0
     return (theta + delta) / denominator * 10.0
+
+
+def alpha_theta_ratio(sample: Dict[str, float]) -> float:
+    """Return theta/alpha ratio from an EEG sample."""
+    theta = sample.get("theta", 0.0)
+    alpha = sample.get("alpha", 0.0)
+    if alpha == 0:
+        return 0.0
+    return theta / alpha
+
+
+def alpha_theta_crossover(sample: Dict[str, float]) -> bool:
+    """Return True if theta power exceeds alpha power."""
+    return sample.get("theta", 0.0) > sample.get("alpha", 0.0)


### PR DESCRIPTION
## Summary
- add alpha-theta ratio utilities
- show crossover status in monitor mode
- document new feature in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src python -m thetagate.cli monitor --interval 0.1 --no-crossover-alert`

------
https://chatgpt.com/codex/tasks/task_e_68541977fa988324b4f8ceb419aa35e4