### PR TITLE
Add Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ python -m thetagate run-script scripts/sample.txt --delay 3
 python -m thetagate run-script scripts/sample.txt --voice-id "YOUR_VOICE_ID"
 ```
 
+## Web UI
+
+Launch a simple browser interface to view EEG samples and run scripts:
+
+```bash
+python -m thetagate web
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 elevenlabs>=2.3.0
+flask>=2.3

--- a/src/thetagate/cli.py
+++ b/src/thetagate/cli.py
@@ -5,6 +5,12 @@ from pathlib import Path
 from . import eeg, trance, script_runner, speech
 
 
+def _start_web(host: str, port: int) -> None:
+    from . import web
+
+    web.app.run(host=host, port=port)
+
+
 def run(args: argparse.Namespace) -> None:
     if args.command == "monitor":
         print("Streaming simulated EEG data. Press Ctrl+C to stop.")
@@ -37,6 +43,8 @@ def run(args: argparse.Namespace) -> None:
                 api_key=args.api_key,
             )
         script_runner.run_script(lines, delay=args.delay, speech_settings=settings)
+    elif args.command == "web":
+        _start_web(args.host, args.port)
     else:
         print("Unknown command")
 
@@ -75,6 +83,9 @@ def parse_args(argv=None) -> argparse.Namespace:
         "--api-key",
         help="ElevenLabs API key (defaults to ELEVENLABS_API_KEY env variable)",
     )
+    web_cmd = sub.add_parser("web", help="Start web interface")
+    web_cmd.add_argument("--host", default="127.0.0.1", help="Host to bind")
+    web_cmd.add_argument("--port", type=int, default=5000, help="Port to bind")
 
 
     return parser.parse_args(argv)

--- a/src/thetagate/web.py
+++ b/src/thetagate/web.py
@@ -1,0 +1,61 @@
+from flask import Flask, render_template_string, Response, request
+from pathlib import Path
+import json
+import threading
+
+from . import eeg, script_runner
+
+app = Flask(__name__)
+
+HTML = """
+<!doctype html>
+<title>ThetaGate</title>
+<h1>ThetaGate Web UI</h1>
+<h2>EEG Stream</h2>
+<pre id="stream">Connecting...</pre>
+
+<script>
+var source = new EventSource('/samples');
+source.onmessage = function(event) {
+    document.getElementById('stream').textContent = event.data;
+};
+</script>
+
+<h2>Run Script</h2>
+<form action="/run-script" method="post">
+    <label>Path: <input type="text" name="path" value="scripts/sample.txt" size="40"></label><br>
+    <label>Delay: <input type="number" step="0.1" name="delay" value="5.0"></label><br>
+    <button type="submit">Run</button>
+</form>
+"""
+
+
+@app.route('/')
+def index():
+    return render_template_string(HTML)
+
+
+@app.route('/samples')
+def samples():
+    def generate():
+        for sample in eeg.stream(1.0):
+            yield f"data: {json.dumps(sample)}\n\n"
+    return Response(generate(), mimetype='text/event-stream')
+
+
+def _run_script(path: str, delay: float) -> None:
+    lines = Path(path).read_text().splitlines()
+    script_runner.run_script(lines, delay=delay)
+
+
+@app.post('/run-script')
+def run_script():
+    path = request.form.get('path', 'scripts/sample.txt')
+    delay = float(request.form.get('delay', 5.0))
+    thread = threading.Thread(target=_run_script, args=(path, delay), daemon=True)
+    thread.start()
+    return 'Running script...'
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- add a small Flask app for browser-based control
- expose `web` command via CLI
- document new web interface in README
- include Flask in requirements

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src python -m thetagate.cli --help`
- `PYTHONPATH=src python -m thetagate.cli web --host 127.0.0.1 --port 5002`

------
https://chatgpt.com/codex/tasks/task_e_6854286e97c08324ba95ac43dc876285